### PR TITLE
Fix context_key reference in ppyaml

### DIFF
--- a/lib/puppet/functions/tahu/ppyaml_key.rb
+++ b/lib/puppet/functions/tahu/ppyaml_key.rb
@@ -27,14 +27,13 @@ Puppet::Functions.create_function(:'tahu::ppyaml_key') do
 
   require 'yaml'
 
-  context_key = :'tahu::ppyaml'
-
   def yaml_data(key, options, context)
     # Recursion detection is tricky since evaluation of puppet logic can call the `lookup` function and start a 
     # new invocation. The protection here is not perfect but will detect if recursion occurs for the very same key
     # when hitting the logic here. This is done by picking up an invocation from an earlier call in the puppet context,
     # and using this invocation to check for recursion on the same key.
     #
+    context_key = :'tahu::ppyaml'
     invocation, level = Puppet.lookup(context_key) { [context.invocation, 0] }
     next_level = invocation.equal?(context.invocation) ? level : level + 1
     Puppet.override({context_key => [invocation, next_level]}, "Protect against recursive lookup/eval of same key") do


### PR DESCRIPTION
Fix for undefined variable error for `context_key` when attempting to use the `ppyaml` hiera backend function.